### PR TITLE
Ensure path seperator between dirname and filename

### DIFF
--- a/source/menu-list.c
+++ b/source/menu-list.c
@@ -138,7 +138,7 @@ int menuFileAssocScan(const char* target)
 			continue;
 
 		memset(temp, 0, sizeof(temp));
-		snprintf(temp, sizeof(temp) - 1, "%s%s", s_menuFileAssoc[!s_curMenuFileAssoc].dirname, dp->d_name);
+		snprintf(temp, sizeof(temp) - 1, "%s/%s", s_menuFileAssoc[!s_curMenuFileAssoc].dirname, dp->d_name);
 
 		const char* ext = getExtension(dp->d_name);
 		if (strcasecmp(ext, ".cfg") != 0)
@@ -188,7 +188,7 @@ int menuScan(const char* target)
 		if (!me)
 			continue;
 
-		snprintf(me->path, sizeof(me->path), "%s%s", s_menu[!s_curMenu].dirname, dp->d_name);
+		snprintf(me->path, sizeof(me->path), "%s/%s", s_menu[!s_curMenu].dirname, dp->d_name);
 		if (menuEntryLoad(me, dp->d_name, shortcut))
 			menuAddEntry(me);
 		else


### PR DESCRIPTION
Previously new-hbmenu assumed that dirname always ended with a '/'. This used to be the case with devkitARM, however this is not portable, and on for example, linux the path does not end in a '/'.

Recently devkitARM was changed to ensure that the path never ends in '/'. https://github.com/devkitPro/newlib/commit/806a4d34c5408d393dbd2b6b9cae22184c57d3a8